### PR TITLE
Fix incorrect bbox scaling

### DIFF
--- a/src/vila/predictors.py
+++ b/src/vila/predictors.py
@@ -61,7 +61,7 @@ def normalize_bbox(
     if page_width > target_width:
         x1 = float(x1) / page_width * target_width
         x2 = float(x2) / page_width * target_width
-        
+
     if page_height > target_height:
         y1 = float(y1) / page_height * target_height
         y2 = float(y2) / page_height * target_height
@@ -252,15 +252,16 @@ class BasePDFPredictor:
                 self.preprocessor.tokenizer.unk_token,
             )
 
-        sample = self.preprocessor.preprocess_sample(pdf_data)
-        sample["bbox"] = [
-            [normalize_bbox(bbox, page_width, page_height) for bbox in batch]
-            for batch in sample["bbox"]
+        _bbox = pdf_data["bbox"]
+        pdf_data["bbox"] = [
+            normalize_bbox(box, page_width, page_height) for box in pdf_data["bbox"]
         ]
+        sample = self.preprocessor.preprocess_sample(pdf_data)
 
         # Change back to the original pdf_data
         pdf_data["labels"] = _labels
         pdf_data["words"] = _words
+        pdf_data["bbox"] = _bbox
 
         return sample
 

--- a/src/vila/predictors.py
+++ b/src/vila/predictors.py
@@ -58,10 +58,11 @@ def normalize_bbox(
 
     # Right now only execute this for only "large" PDFs
     # TODO: Change it for all PDFs
-    if page_width > target_width or page_height > target_height:
-
+    if page_width > target_width:
         x1 = float(x1) / page_width * target_width
         x2 = float(x2) / page_width * target_width
+        
+    if page_height > target_height:
         y1 = float(y1) / page_height * target_height
         y2 = float(y2) / page_height * target_height
 

--- a/src/vila/predictors.py
+++ b/src/vila/predictors.py
@@ -59,23 +59,28 @@ def normalize_bbox(
 
     # Right now only execute this for only "large" PDFs
     # TODO: Change it for all PDFs
-    if page_width > target_width:
-        logger.warning(f"Scaling page horizontally as page width {page_width} is larger than target width {target_width}")
-        x1 = float(x1) / page_width * target_width
-        x2 = float(x2) / page_width * target_width
 
-    if page_height > target_height:
-        logger.warning(f"Scaling page vertically as page height {page_height} is larger than target height {target_height}")
-        y1 = float(y1) / page_height * target_height
-        y2 = float(y2) / page_height * target_height
 
     if x1 > x2:
-        logger.warning(f"Incompatible x coordinates: x1:{x1} > x2{x2}")
+        logger.warning(f"Incompatible x coordinates: x1:{x1} > x2:{x2}")
         x1, x2 = x2, x1
 
     if y1 > y2:
-        logger.warning(f"Incompatible y coordinates: y1:{y1} > y2{y2}")
+        logger.warning(f"Incompatible y coordinates: y1:{y1} > y2:{y2}")
         y1, y2 = y2, y1
+
+    if page_width > target_width or page_height > target_height:
+
+        # Aspect ratio preserving scaling
+        scale_factor = target_width / page_width if page_width > page_height else target_height / page_height
+
+        logger.warning(f"Scaling page as page width {page_width} is larger than target width {target_width} or height {page_height} is larger than target height {target_height}")
+        
+        x1 = float(x1) * scale_factor
+        x2 = float(x2) * scale_factor
+
+        y1 = float(y1) * scale_factor
+        y2 = float(y2) * scale_factor
 
     return (x1, y1, x2, y2)
 
@@ -95,11 +100,19 @@ def unnormalize_bbox(
 
     # Right now only execute this for only "large" PDFs
     # TODO: Change it for all PDFs
+    
     if page_width > target_width or page_height > target_height:
-        x1 = float(x1) / target_width * page_width
-        x2 = float(x2) / target_width * page_width
-        y1 = float(y1) / target_height * page_height
-        y2 = float(y2) / target_height * page_height
+
+        # Aspect ratio preserving scaling
+        scale_factor = target_width / page_width if page_width > page_height else target_height / page_height
+
+        logger.warning(f"Scaling page as page width {page_width} is larger than target width {target_width} or height {page_height} is larger than target height {target_height}")
+        
+        x1 = float(x1) / scale_factor
+        x2 = float(x2) / scale_factor
+
+        y1 = float(y1) / scale_factor
+        y2 = float(y2) / scale_factor
 
     return (x1, y1, x2, y2)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,21 @@
-from vila.predictors import normalize_bbox
+from vila.predictors import normalize_bbox, unnormalize_bbox
 
 
 def test_normalize_bbox():
 
     # fmt: off
     assert normalize_bbox([128, 256, 256, 512], 1000, 1000) == (128, 256, 256, 512)
-    assert normalize_bbox([128, 256, 256, 512], 1000, 1024) == (128, 250.0, 256, 500.0)
-    assert normalize_bbox([128, 256, 256, 512], 1024, 1000) == (125, 256, 250, 512)
+    
+    assert normalize_bbox([128, 256, 256, 512], 1000, 1024) == (125.0, 250.0, 250.0, 500.0)
+    assert normalize_bbox([128, 256, 256, 512], 1024, 1000) == (125.0, 250.0, 250.0, 500.0)
+    
     assert normalize_bbox([128, 256, 256, 512], 1024, 1024) == (125.0, 250.0, 250.0, 500.0)
     assert normalize_bbox([256, 256, 128, 512], 1024, 1024) == (125.0, 250.0, 250.0, 500.0)
+
+    assert unnormalize_bbox((128, 256, 256, 512), 1000, 1000) == (128, 256, 256, 512)
+    
+    assert unnormalize_bbox((125.0, 250.0, 250.0, 500.0), 1000, 1024) == (128, 256, 256, 512)
+    assert unnormalize_bbox((125.0, 250.0, 250.0, 500.0), 1024, 1000) == (128, 256, 256, 512)
+    
+    assert unnormalize_bbox((125.0, 250.0, 250.0, 500.0), 1024, 1024) == (128, 256, 256, 512)
     # fmt: on

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+from vila.predictors import normalize_bbox
+
+
+def test_normalize_bbox():
+
+    # fmt: off
+    assert normalize_bbox([128, 256, 256, 512], 1000, 1000) == (128, 256, 256, 512)
+    assert normalize_bbox([128, 256, 256, 512], 1000, 1024) == (128, 250.0, 256, 500.0)
+    assert normalize_bbox([128, 256, 256, 512], 1024, 1000) == (125, 256, 250, 512)
+    assert normalize_bbox([128, 256, 256, 512], 1024, 1024) == (125.0, 250.0, 250.0, 500.0)
+    assert normalize_bbox([256, 256, 128, 512], 1024, 1024) == (125.0, 250.0, 250.0, 500.0)
+    # fmt: on

--- a/tests/test_vila_run.py
+++ b/tests/test_vila_run.py
@@ -81,3 +81,73 @@ def test_vila_run_with_special_unicode_inputs():
 
     with pytest.raises(AssertionError):
         pdf_predictor.predict(pdf_data, (596, 842), replace_empty_unicode=False)
+
+
+def test_vila_run_bbox():
+
+    pdf_data = {
+        "words": ["\uf02a", "New", "Modalities"],
+        "block_ids": [0, 0, 0],
+    }
+
+    pdf_predictor = LayoutIndicatorPDFPredictor.from_pretrained(
+        "allenai/ivila-block-layoutlm-finetuned-docbank"
+    )
+
+    # Case 1: Good boxes 
+    bbox =  [
+        [82, 70, 123, 84],
+        [127, 70, 191, 84],
+        [195, 70, 262, 84],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (596, 800))
+
+    # Case 2: Good boxes -- float
+    bbox =  [
+        [82.806, 70.34515579999993, 123.4487846, 84.6913558],
+        [127.0353346, 70.34515579999993, 191.9949282, 84.6913558],
+        [195.5814782, 70.34515579999993, 262.26261580000005, 84.6913558],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (596, 800))
+
+    # Case 3: Large Pages - height 
+
+    bbox =  [
+        [82.806, 70.34515579999993, 123.4487846, 84.6913558],
+        [127.0353346, 70.34515579999993, 191.9949282, 84.6913558],
+        [195.5814782, 70.34515579999993, 262.26261580000005, 84.6913558],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (596, 1200))
+
+    # Case 4: Large Pages - width 
+
+    bbox =  [
+        [82.806, 70.34515579999993, 123.4487846, 84.6913558],
+        [127.0353346, 70.34515579999993, 191.9949282, 84.6913558],
+        [195.5814782, 70.34515579999993, 262.26261580000005, 84.6913558],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (1200, 596))
+
+    # Case 5: Large Pages - Both 
+
+    bbox =  [
+        [82.806, 70.34515579999993, 123.4487846, 84.6913558],
+        [127.0353346, 70.34515579999993, 191.9949282, 84.6913558],
+        [195.5814782, 70.34515579999993, 262.26261580000005, 84.6913558],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (1200, 1200))
+
+    # C Case 6: Incorrect Bbox (x1>x2)
+
+    bbox =  [
+        [82.806, 70.34515579999993, 123.4487846, 84.6913558],
+        [191.9949282, 70.34515579999993, 127.0353346, 84.6913558],
+        [296, 70.34515579999993, 262.26261580000005, 84.6913558],
+    ]
+    pdf_data["bbox"] = bbox
+    pdf_predictor.predict(pdf_data, (1200, 1200))


### PR DESCRIPTION
In the previous version, there are two errors in the box normalization step:

1. we'll scale the bbox for both the height and width dimension even if only one dimension is oversized 
2. we perform the scaling after inserting the special tokens, which might have the `[1000,1000,1000,1000] box

As such, let's say we have a page of size (700, 1024) (width, height). In the previous normalization, it will:
1. scale the width dimension to 1000 
2. since it normalizes after injecting a special token of coordinate `1000`, it will resize it into `1000*1000/700=1428`, which defeats the purpose of resizing. 

In the new fix, we 
1. make sure only scale the large side 
2. we do the scaling before injecting the special tokens. 